### PR TITLE
Depthbuffer Improvement (16 bit and 32bit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Minecraft mod for offline rendering and video capturing.
 Butter smooth 1080p60, supersampled from 4K, up to 64 chunks render distance and up to 4096x4096 shadow maps. Recorded on a single GTX 750 Ti.
 
 **Current features:**
-- Records the game, both color and optionally **depth**
+- Records the game, both color and optionally **alpha** or **depth (8bit, 16bit or 32bit float variant)**
 - Automatically exports every frame as TGA or encodes it to a single mp4 video file (h264, yuv420p color format) using [FFMpeg](https://www.ffmpeg.org/)
 - Synchronizes the game engine and [OptiFine](https://optifine.net/home)'s/[karyonix](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1286604-shaders-mod-updated-by-karyonix)'s shader pipeline from real time to the video recording framerate
 - Possible to set any resolution for recording, even higher than your screen resolution

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 apply plugin: 'net.minecraftforge.gradle.forge'
 //Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
-version = "3.6.2"
+version = "3.6.4"
 
 if (project.hasProperty("dev")) {
     version += "-dev" + dev

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 apply plugin: 'net.minecraftforge.gradle.forge'
 //Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
-version = "3.6.4"
+version = "3.7"
 
 if (project.hasProperty("dev")) {
     version += "-dev" + dev

--- a/src/main/java/info/ata4/minecraft/minema/client/config/MinemaConfig.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/config/MinemaConfig.java
@@ -9,6 +9,7 @@
  */
 package info.ata4.minecraft.minema.client.config;
 
+import info.ata4.minecraft.minema.client.config.enums.BitDepth;
 import info.ata4.minecraft.minema.client.config.enums.MotionBlur;
 import info.ata4.minecraft.minema.client.config.enums.SnapResolution;
 import info.ata4.minecraft.minema.util.config.ConfigBoolean;
@@ -55,6 +56,9 @@ public class MinemaConfig {
 			"-f rawvideo -pix_fmt bgr24 -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -c:v libx264 -preset ultrafast -tune zerolatency -qp 18 -pix_fmt yuv420p %NAME%.mp4");
 	public final ConfigString videoEncoderParamsAlpha = new ConfigString(
 			"-f rawvideo -pix_fmt rgb32 -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -c:v libx264 -preset ultrafast -tune zerolatency -qp 18 -pix_fmt yuv420p %NAME%_rgb.mp4 -vf %DEFVF%,alphaextract,format=yuv420p %NAME%_alpha.mp4");
+	public final ConfigString videoEncoderParamsDepth = new ConfigString(
+			"-f rawvideo -pix_fmt bgr48be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -pix_fmt bgr48be %NAME%_depth_%d.png");
+	public final ConfigEnum<BitDepth> depthBufferBitDepth = new ConfigEnum<>(BitDepth.BIT16);
 	public final ConfigEnum<SnapResolution> snapResolution = new ConfigEnum<>(SnapResolution.MOD2);
 	public final ConfigBoolean enableEncoderLogging = new ConfigBoolean(true);
 
@@ -113,6 +117,8 @@ public class MinemaConfig {
 		videoEncoderPath.link(cfg, ENCODING_CATEGORY, "videoEncoderPath", LANG_KEY);
 		videoEncoderParams.link(cfg, ENCODING_CATEGORY, "videoEncoderParams", LANG_KEY);
 		videoEncoderParamsAlpha.link(cfg, ENCODING_CATEGORY, "videoEncoderParamsAlpha", LANG_KEY);
+		videoEncoderParamsDepth.link(cfg, ENCODING_CATEGORY, "videoEncoderParamsDepth", LANG_KEY);
+		depthBufferBitDepth.link(cfg, ENCODING_CATEGORY, "depthBufferBitDepth", LANG_KEY);
 		snapResolution.link(cfg, ENCODING_CATEGORY, "snapResolution", LANG_KEY);
 		enableEncoderLogging.link(cfg, ENCODING_CATEGORY, "enableEncoderLogging", LANG_KEY);
 

--- a/src/main/java/info/ata4/minecraft/minema/client/config/MinemaConfig.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/config/MinemaConfig.java
@@ -58,7 +58,7 @@ public class MinemaConfig {
 			"-f rawvideo -pix_fmt rgb32 -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -c:v libx264 -preset ultrafast -tune zerolatency -qp 18 -pix_fmt yuv420p %NAME%_rgb.mp4 -vf %DEFVF%,alphaextract,format=yuv420p %NAME%_alpha.mp4");
 	public final ConfigString videoEncoderParamsDepth = new ConfigString(
 			"-f rawvideo -pix_fmt bgr48be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -pix_fmt bgr48be %NAME%_depth_%d.png");
-	public final ConfigEnum<BitDepth> depthBufferBitDepth = new ConfigEnum<>(BitDepth.BIT16);
+	public final ConfigEnum<BitDepth> depthBufferBitDepth = new ConfigEnum<>(BitDepth.BIT16CHANNELS3);
 	public final ConfigEnum<SnapResolution> snapResolution = new ConfigEnum<>(SnapResolution.MOD2);
 	public final ConfigBoolean enableEncoderLogging = new ConfigBoolean(true);
 

--- a/src/main/java/info/ata4/minecraft/minema/client/config/MinemaConfig.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/config/MinemaConfig.java
@@ -23,6 +23,7 @@ import net.minecraft.client.resources.I18n;
 import net.minecraftforge.common.config.ConfigCategory;
 import net.minecraftforge.common.config.ConfigElement;
 import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.fml.client.config.GuiConfigEntries;
 import net.minecraftforge.fml.client.config.IConfigElement;
 import org.apache.commons.lang3.text.WordUtils;
 import org.lwjgl.opengl.Display;
@@ -56,9 +57,9 @@ public class MinemaConfig {
 			"-f rawvideo -pix_fmt bgr24 -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -c:v libx264 -preset ultrafast -tune zerolatency -qp 18 -pix_fmt yuv420p %NAME%.mp4");
 	public final ConfigString videoEncoderParamsAlpha = new ConfigString(
 			"-f rawvideo -pix_fmt rgb32 -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -c:v libx264 -preset ultrafast -tune zerolatency -qp 18 -pix_fmt yuv420p %NAME%_rgb.mp4 -vf %DEFVF%,alphaextract,format=yuv420p %NAME%_alpha.mp4");
-	public final ConfigString videoEncoderParamsDepth = new ConfigString(
+	public static final ConfigString videoEncoderParamsDepth = new ConfigString(
 			"-f rawvideo -pix_fmt bgra64be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -pix_fmt bgra64be %NAME%_depth_%d.png");
-	public final ConfigEnum<BitDepth> depthBufferBitDepth = new ConfigEnum<>(BitDepth.BIT16CHANNELS4);
+	public static final ConfigEnum<BitDepth> depthBufferBitDepth = new ConfigEnum<>(BitDepth.BIT16CHANNELS4);
 	public final ConfigEnum<SnapResolution> snapResolution = new ConfigEnum<>(SnapResolution.MOD2);
 	public final ConfigBoolean enableEncoderLogging = new ConfigBoolean(true);
 
@@ -217,4 +218,11 @@ public class MinemaConfig {
 		return frameLimit.get() * (useVideoEncoder.get() ? 1 << motionBlurLevel.get().getExp(frameRate.get()) : 1);
 	}
 
+	public static void ASMAfterCyclicEntryUpdateText(GuiConfigEntries.CycleValueEntry button)
+	{
+		if (button.getName().equals(depthBufferBitDepth.getProp().getName()))
+		{
+			videoEncoderParamsDepth.getProp().setDefaultValue(BitDepth.valueOf(button.getCurrentValue().toUpperCase()).getParams());
+		}
+	}
 }

--- a/src/main/java/info/ata4/minecraft/minema/client/config/MinemaConfig.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/config/MinemaConfig.java
@@ -58,8 +58,9 @@ public class MinemaConfig {
 	public final ConfigString videoEncoderParamsAlpha = new ConfigString(
 			"-f rawvideo -pix_fmt rgb32 -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -c:v libx264 -preset ultrafast -tune zerolatency -qp 18 -pix_fmt yuv420p %NAME%_rgb.mp4 -vf %DEFVF%,alphaextract,format=yuv420p %NAME%_alpha.mp4");
 	public static final ConfigString videoEncoderParamsDepth = new ConfigString(
-			"-f rawvideo -pix_fmt bgra64be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -pix_fmt bgra64be %NAME%_depth_%d.png");
-	public static final ConfigEnum<BitDepth> depthBufferBitDepth = new ConfigEnum<>(BitDepth.BIT16CHANNELS4);
+			"-f rawvideo -pix_fmt bgr48be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -pix_fmt bgr48be %NAME%_depth_%d.png");
+	public static final ConfigEnum<BitDepth> depthBufferBitDepth = new ConfigEnum<>(BitDepth.BIT16CHANNELS3);
+	public final ConfigBoolean depthBufferMotionBlur = new ConfigBoolean(false);
 	public final ConfigEnum<SnapResolution> snapResolution = new ConfigEnum<>(SnapResolution.MOD2);
 	public final ConfigBoolean enableEncoderLogging = new ConfigBoolean(true);
 
@@ -120,6 +121,7 @@ public class MinemaConfig {
 		videoEncoderParamsAlpha.link(cfg, ENCODING_CATEGORY, "videoEncoderParamsAlpha", LANG_KEY);
 		videoEncoderParamsDepth.link(cfg, ENCODING_CATEGORY, "videoEncoderParamsDepth", LANG_KEY);
 		depthBufferBitDepth.link(cfg, ENCODING_CATEGORY, "depthBufferBitDepth", LANG_KEY);
+		depthBufferMotionBlur.link(cfg, ENCODING_CATEGORY, "depthBufferMotionBlur", LANG_KEY);
 		snapResolution.link(cfg, ENCODING_CATEGORY, "snapResolution", LANG_KEY);
 		enableEncoderLogging.link(cfg, ENCODING_CATEGORY, "enableEncoderLogging", LANG_KEY);
 

--- a/src/main/java/info/ata4/minecraft/minema/client/config/MinemaConfig.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/config/MinemaConfig.java
@@ -57,8 +57,8 @@ public class MinemaConfig {
 	public final ConfigString videoEncoderParamsAlpha = new ConfigString(
 			"-f rawvideo -pix_fmt rgb32 -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -c:v libx264 -preset ultrafast -tune zerolatency -qp 18 -pix_fmt yuv420p %NAME%_rgb.mp4 -vf %DEFVF%,alphaextract,format=yuv420p %NAME%_alpha.mp4");
 	public final ConfigString videoEncoderParamsDepth = new ConfigString(
-			"-f rawvideo -pix_fmt bgr48be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -pix_fmt bgr48be %NAME%_depth_%d.png");
-	public final ConfigEnum<BitDepth> depthBufferBitDepth = new ConfigEnum<>(BitDepth.BIT16CHANNELS3);
+			"-f rawvideo -pix_fmt bgra64be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -pix_fmt bgra64be %NAME%_depth_%d.png");
+	public final ConfigEnum<BitDepth> depthBufferBitDepth = new ConfigEnum<>(BitDepth.BIT16CHANNELS4);
 	public final ConfigEnum<SnapResolution> snapResolution = new ConfigEnum<>(SnapResolution.MOD2);
 	public final ConfigBoolean enableEncoderLogging = new ConfigBoolean(true);
 

--- a/src/main/java/info/ata4/minecraft/minema/client/config/enums/BitDepth.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/config/enums/BitDepth.java
@@ -1,0 +1,36 @@
+package info.ata4.minecraft.minema.client.config.enums;
+
+import static org.lwjgl.opengl.GL11.*;
+
+public enum BitDepth
+{
+    BIT8( 1, GL_UNSIGNED_BYTE, "-f rawvideo -pix_fmt bgr24 -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -c:v libx264 -preset ultrafast -tune zerolatency -qp 6 -pix_fmt yuv420p %NAME%_depth.mp4"),
+    BIT16( 2, GL_UNSIGNED_SHORT, "-f rawvideo -pix_fmt bgr48be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -pix_fmt bgr48be %NAME%_depth_%d.png"),
+    BIT32( 4, GL_FLOAT, "-f rawvideo -pix_fmt gbrpf32be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -compression zip1 -pix_fmt gbrpf32be %NAME%_depth_%d.exr");
+
+    private int depth;
+    private int glFormat;
+    private String ffmpegParams;
+
+    BitDepth(int depth, int glFormat, String ffmpegParams)
+    {
+        this.depth = depth;
+        this.glFormat = glFormat;
+        this.ffmpegParams = ffmpegParams;
+    }
+
+    public int getBytesPerChannel()
+    {
+        return this.depth;
+    }
+
+    public String getParams()
+    {
+        return this.ffmpegParams;
+    }
+
+    public int getFormat()
+    {
+        return this.glFormat;
+    }
+}

--- a/src/main/java/info/ata4/minecraft/minema/client/config/enums/BitDepth.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/config/enums/BitDepth.java
@@ -6,7 +6,7 @@ public enum BitDepth
 {
     BIT8( 1, GL_UNSIGNED_BYTE, "-f rawvideo -pix_fmt bgr24 -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -c:v libx264 -preset ultrafast -tune zerolatency -qp 6 -pix_fmt yuv420p %NAME%_depth.mp4"),
     BIT16( 2, GL_UNSIGNED_SHORT, "-f rawvideo -pix_fmt bgr48be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -pix_fmt bgr48be %NAME%_depth_%d.png"),
-    BIT32( 4, GL_FLOAT, "-f rawvideo -pix_fmt gbrpf32be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -compression zip1 -pix_fmt gbrpf32be %NAME%_depth_%d.exr");
+    BIT32( 4, GL_FLOAT, "-f rawvideo -pix_fmt grayf32be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -compression zip1 -pix_fmt gbrpf32be %NAME%_depth_%d.exr");
 
     private int depth;
     private int glFormat;

--- a/src/main/java/info/ata4/minecraft/minema/client/config/enums/BitDepth.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/config/enums/BitDepth.java
@@ -4,17 +4,20 @@ import static org.lwjgl.opengl.GL11.*;
 
 public enum BitDepth
 {
-    BIT8( 1, GL_UNSIGNED_BYTE, "-f rawvideo -pix_fmt bgr24 -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -c:v libx264 -preset ultrafast -tune zerolatency -qp 6 -pix_fmt yuv420p %NAME%_depth.mp4"),
-    BIT16( 2, GL_UNSIGNED_SHORT, "-f rawvideo -pix_fmt bgr48be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -pix_fmt bgr48be %NAME%_depth_%d.png"),
-    BIT32( 4, GL_FLOAT, "-f rawvideo -pix_fmt grayf32be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -compression zip1 -pix_fmt gbrpf32be %NAME%_depth_%d.exr");
+    BIT8( 1,3, GL_UNSIGNED_BYTE, "-f rawvideo -pix_fmt bgr24 -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -c:v libx264 -preset ultrafast -tune zerolatency -qp 6 -pix_fmt yuv420p %NAME%_depth.mp4"),
+    BIT16CHANNELS3( 2,3, GL_UNSIGNED_SHORT, "-f rawvideo -pix_fmt bgr48be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -pix_fmt bgr48be %NAME%_depth_%d.png"),
+    BIT16CHANNELS4( 2,4, GL_UNSIGNED_SHORT, "-f rawvideo -pix_fmt bgra64be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -pix_fmt bgra64be %NAME%_depth_%d.png"),
+    BIT32F( 4,1, GL_FLOAT, "-f rawvideo -pix_fmt grayf32be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -compression zip1 -pix_fmt gbrpf32le %NAME%_depth_%d.exr");
 
     private int depth;
+    private int channels;
     private int glFormat;
     private String ffmpegParams;
 
-    BitDepth(int depth, int glFormat, String ffmpegParams)
+    BitDepth(int depth, int channels, int glFormat, String ffmpegParams)
     {
         this.depth = depth;
+        this.channels = channels;
         this.glFormat = glFormat;
         this.ffmpegParams = ffmpegParams;
     }
@@ -22,6 +25,11 @@ public enum BitDepth
     public int getBytesPerChannel()
     {
         return this.depth;
+    }
+
+    public int getChannels()
+    {
+        return this.channels;
     }
 
     public String getParams()

--- a/src/main/java/info/ata4/minecraft/minema/client/config/enums/BitDepth.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/config/enums/BitDepth.java
@@ -7,7 +7,7 @@ public enum BitDepth
     BIT8( 1,3, GL_UNSIGNED_BYTE, "-f rawvideo -pix_fmt bgr24 -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -c:v libx264 -preset ultrafast -tune zerolatency -qp 6 -pix_fmt yuv420p %NAME%_depth.mp4"),
     BIT16CHANNELS3( 2,3, GL_UNSIGNED_SHORT, "-f rawvideo -pix_fmt bgr48be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -pix_fmt bgr48be %NAME%_depth_%d.png"),
     BIT16CHANNELS4( 2,4, GL_UNSIGNED_SHORT, "-f rawvideo -pix_fmt bgra64be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -pix_fmt bgra64be %NAME%_depth_%d.png"),
-    BIT32F( 4,1, GL_FLOAT, "-f rawvideo -pix_fmt grayf32be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -compression zip1 -pix_fmt gbrpf32le %NAME%_depth_%d.exr");
+    BIT32F( 4,3, GL_FLOAT, "-f rawvideo -pix_fmt gbrpf32be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -compression zip1 -pix_fmt gbrpf32le %NAME%_depth_%d.exr");
 
     private int depth;
     private int channels;

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/AbstractVideoHandler.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/AbstractVideoHandler.java
@@ -68,15 +68,10 @@ public abstract class AbstractVideoHandler extends CaptureModule {
 		if (!cfg.useVideoEncoder.get())
 		{
 			Path colorDir = CaptureSession.singleton.getCaptureDir().resolve(colorName);
-			Path depthDir = CaptureSession.singleton.getCaptureDir().resolve(colorName);
 
 			if (!Files.exists(colorDir))
 			{
 				Files.createDirectory(colorDir);
-			}
-			if (recordDepth && !Files.exists(depthDir))
-			{
-				Files.createDirectory(depthDir);
 			}
 		}
 

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/AbstractVideoHandler.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/AbstractVideoHandler.java
@@ -32,7 +32,6 @@ public abstract class AbstractVideoHandler extends CaptureModule {
 	protected FrameExporter depthExport;
 
 	protected String colorName;
-	protected String depthName;
 	
 	protected boolean recordDepth;
 
@@ -41,13 +40,13 @@ public abstract class AbstractVideoHandler extends CaptureModule {
 	protected boolean recordGui;
 
 	@Override
-	protected void doEnable() throws Exception {
+	protected void doEnable() throws Exception
+	{
 		MinemaConfig cfg = Minema.instance.getConfig();
 
 		this.startWidth = MC.displayWidth;
 		this.startHeight = MC.displayHeight;
 		this.colorName = customName == null || customName.isEmpty() ? new SimpleDateFormat("yyyy-MM-dd_HH.mm.ss").format(new Date()) : customName;
-		this.depthName = colorName.concat("depthBuffer");
 		this.recordGui = cfg.recordGui.get();
         this.recordDepth = cfg.captureDepth.get();
 
@@ -60,26 +59,33 @@ public abstract class AbstractVideoHandler extends CaptureModule {
 		colorReader = new ColorbufferReader(startWidth, startHeight, 1, usePBO, useFBO, cfg.useAlpha.get());
 		colorExport = usePipe ? new PipeFrameExporter(true) : new ImageFrameExporter(true);
 
-		if (recordDepth) {
+		if (recordDepth)
+		{
 			depthReader = new DepthbufferReader(startWidth, startHeight, usePBO, useFBO, cfg.captureDepthDistance.get().floatValue());
 			depthExport = usePipe ? new PipeFrameExporter(false) : new ImageFrameExporter(false);
 		}
 
-		if (!Minema.instance.getConfig().useVideoEncoder.get()) {
+		if (!cfg.useVideoEncoder.get())
+		{
 			Path colorDir = CaptureSession.singleton.getCaptureDir().resolve(colorName);
-			Path depthDir = CaptureSession.singleton.getCaptureDir().resolve(depthName);
+			Path depthDir = CaptureSession.singleton.getCaptureDir().resolve(colorName);
 
-			if (!Files.exists(colorDir)) {
+			if (!Files.exists(colorDir))
+			{
 				Files.createDirectory(colorDir);
 			}
-			if (recordDepth && !Files.exists(depthDir)) {
+			if (recordDepth && !Files.exists(depthDir))
+			{
 				Files.createDirectory(depthDir);
 			}
 		}
 
-		colorExport.enable(colorName, startWidth, startHeight, 8);
+		colorExport.enable(colorName, startWidth, startHeight);
+
 		if (depthExport != null)
-			depthExport.enable(depthName, startWidth, startHeight, 16);
+		{
+			depthExport.enable(colorName, startWidth, startHeight);
+		}
 
 		MinemaEventbus.midRenderBUS.registerListener((e) -> onRenderMid(e));
 		MinemaEventbus.endRenderBUS.registerListener((e) -> onRenderEnd(e));

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/AbstractVideoHandler.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/AbstractVideoHandler.java
@@ -57,7 +57,7 @@ public abstract class AbstractVideoHandler extends CaptureModule {
 
 		CaptureSession.singleton.setFilename(colorName);
 		customName = null;
-		colorReader = new ColorbufferReader(startWidth, startHeight, usePBO, useFBO, cfg.useAlpha.get());
+		colorReader = new ColorbufferReader(startWidth, startHeight, 1, usePBO, useFBO, cfg.useAlpha.get());
 		colorExport = usePipe ? new PipeFrameExporter(true) : new ImageFrameExporter(true);
 
 		if (recordDepth) {
@@ -77,9 +77,9 @@ public abstract class AbstractVideoHandler extends CaptureModule {
 			}
 		}
 
-		colorExport.enable(colorName, startWidth, startHeight);
+		colorExport.enable(colorName, startWidth, startHeight, 8);
 		if (depthExport != null)
-			depthExport.enable(depthName, startWidth, startHeight);
+			depthExport.enable(depthName, startWidth, startHeight, 16);
 
 		MinemaEventbus.midRenderBUS.registerListener((e) -> onRenderMid(e));
 		MinemaEventbus.endRenderBUS.registerListener((e) -> onRenderEnd(e));

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/ColorbufferReader.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/ColorbufferReader.java
@@ -20,8 +20,8 @@ public class ColorbufferReader extends CommonReader {
 
 	public Framebuffer fb;
 	
-	public ColorbufferReader(int width, int height, boolean isPBO, boolean isFBO, boolean isAlpha) {
-		super(width, height, isAlpha ? 4 : 3, GL_UNSIGNED_BYTE, isAlpha ? GL_BGRA : GL_BGR, isPBO, isFBO);
+	public ColorbufferReader(int width, int height, int bytesPerChannel, boolean isPBO, boolean isFBO, boolean isAlpha) {
+		super(width, height, bytesPerChannel * (isAlpha ? 4 : 3), GL_UNSIGNED_BYTE, isAlpha ? GL_BGRA : GL_BGR, isPBO, isFBO);
 	}
 
 	@Override

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/ColorbufferReader.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/ColorbufferReader.java
@@ -20,8 +20,14 @@ public class ColorbufferReader extends CommonReader {
 
 	public Framebuffer fb;
 	
-	public ColorbufferReader(int width, int height, int bytesPerChannel, boolean isPBO, boolean isFBO, boolean isAlpha) {
+	public ColorbufferReader(int width, int height, int bytesPerChannel, boolean isPBO, boolean isFBO, boolean isAlpha)
+	{
 		super(width, height, bytesPerChannel * (isAlpha ? 4 : 3), GL_UNSIGNED_BYTE, isAlpha ? GL_BGRA : GL_BGR, isPBO, isFBO);
+	}
+
+	public ColorbufferReader(int width, int height, int bytesPerChannel, int FORMAT, boolean isPBO, boolean isFBO, boolean isAlpha)
+	{
+		super(width, height, bytesPerChannel * (isAlpha ? 4 : 3), FORMAT, isAlpha ? GL_BGRA : GL_BGR, isPBO, isFBO);
 	}
 
 	@Override

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/CommonReader.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/CommonReader.java
@@ -57,7 +57,7 @@ public abstract class CommonReader {
 	protected int backName;
 	protected boolean firstFrame;
 
-	public CommonReader(int width, int height, int BPP, int TYPE, int FORMAT, boolean isPBO, boolean isFBO) {
+	public CommonReader(int width, int height, int bytesPerPixel, int TYPE, int FORMAT, boolean isPBO, boolean isFBO) {
 		this.TYPE = TYPE;
 		this.FORMAT = FORMAT;
 		this.isPBO = isPBO;
@@ -65,9 +65,10 @@ public abstract class CommonReader {
 		this.width = width;
 		this.height = height;
 
-		bufferSize = width * height * BPP;
+		this.bufferSize = width * height * bytesPerPixel;
 
-		if (isPBO) {
+		if (isPBO)
+		{
 			frontName = glGenBuffersARB();
 			glBindBufferARB(PBO_TARGET, frontName);
 			glBufferDataARB(PBO_TARGET, bufferSize, PBO_USAGE);
@@ -79,8 +80,11 @@ public abstract class CommonReader {
 			glBindBufferARB(PBO_TARGET, 0);
 
 			firstFrame = true;
-		} else {
+		}
+		else
+		{
 			this.buffer = ByteBuffer.allocateDirect(bufferSize);
+
 			buffer.rewind();
 		}
 	}

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/DepthbufferReader.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/DepthbufferReader.java
@@ -14,6 +14,7 @@ import static org.lwjgl.opengl.GL11.*;
 import java.nio.ByteBuffer;
 
 import info.ata4.minecraft.minema.Minema;
+import info.ata4.minecraft.minema.client.config.enums.BitDepth;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL20;
 import org.lwjgl.opengl.GL30;
@@ -45,10 +46,11 @@ public class DepthbufferReader extends CommonReader {
 		customFar = customFar > 0 ? customFar : MC.gameSettings.renderDistanceChunks * 16;
 		preCalcNear = 0.1F / customFar;
 
-		int bytesPerChannel = Minema.instance.getConfig().depthBufferBitDepth.get().getBytesPerChannel();
-		int format = Minema.instance.getConfig().depthBufferBitDepth.get().getFormat();
+		BitDepth bitDepth = Minema.instance.getConfig().depthBufferBitDepth.get();
+		int bytesPerChannel = bitDepth.getBytesPerChannel();
+		int format = bitDepth.getFormat();
 
-		if (isPBO && isFBO && program > 0) {
+		/*if (isPBO && isFBO && program > 0) {
 			GL20.glUseProgram(program);
 			GL20.glUniform1i(GL20.glGetUniformLocation(program, "tex"), 0);
 			GL20.glUniform1f(GL20.glGetUniformLocation(program, "near"), 0.05f);
@@ -70,12 +72,12 @@ public class DepthbufferReader extends CommonReader {
 
 			proxy = new ColorbufferReader(width, height, bytesPerChannel, format, isPBO, isFBO, false);
 			proxy.fb = new Framebuffer(width, height, false);
-		} else {
+		} else {*/
 			prebuffer = buffer;
 
-			buffer = ByteBuffer.allocateDirect(width * height * 3 * bytesPerChannel);
+			buffer = ByteBuffer.allocateDirect(width * height * ((bitDepth == BitDepth.BIT32) ? 1 : 3) * bytesPerChannel);
 			buffer.rewind();
-		}
+		//}
 	}
 
 	@Override
@@ -255,7 +257,7 @@ public class DepthbufferReader extends CommonReader {
 			switch (Minema.instance.getConfig().depthBufferBitDepth.get())
 			{
 				case BIT8:
-					byte b = (byte) (this.linearizeDepth(depth) * (Math.pow(2,8) - 1));
+					byte b = (byte) (this.linearizeDepth(depth) * (Math.pow(2, 8) - 1));
 
 					buffer.put(b);
 					buffer.put(b);
@@ -263,7 +265,7 @@ public class DepthbufferReader extends CommonReader {
 
 					break;
 				case BIT16:
-					short s = (short) (this.linearizeDepth(depth) * (Math.pow(2,16) - 1));
+					short s = (short) (this.linearizeDepth(depth) * (Math.pow(2, 16) - 1));
 
 					buffer.putShort(s);
 					buffer.putShort(s);
@@ -273,8 +275,6 @@ public class DepthbufferReader extends CommonReader {
 				case BIT32:
 					float f = this.linearizeDepth(depth);
 
-					buffer.putFloat(f);
-					buffer.putFloat(f);
 					buffer.putFloat(f);
 
 					break;

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/DepthbufferReader.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/DepthbufferReader.java
@@ -249,11 +249,13 @@ public class DepthbufferReader extends CommonReader {
 
 	private void writeDepth()
 	{
+		BitDepth bitDepth = Minema.instance.getConfig().depthBufferBitDepth.get();
+
 		while (prebuffer.hasRemaining())
 		{
 			float depth = prebuffer.getFloat();
 
-			switch (Minema.instance.getConfig().depthBufferBitDepth.get())
+			switch (bitDepth)
 			{
 				case BIT8:
 					byte b = (byte) (this.linearizeDepth(depth) * (Math.pow(2, 8) - 1));
@@ -283,14 +285,15 @@ public class DepthbufferReader extends CommonReader {
 				case BIT32F:
 					float f = this.linearizeDepth(depth);
 
-					buffer.putFloat(f);
+					buffer.putFloat(f * this.customFar);
 
 					break;
 			}
 		}
 	}
 
-	private float linearizeDepth(float z) {
+	private float linearizeDepth(float z)
+	{
 		final float near = 0.05f;
 		float far = this.calculateFar();
 

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/VRVideoHandler.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/VRVideoHandler.java
@@ -154,7 +154,7 @@ public class VRVideoHandler extends AbstractVideoHandler {
 				params = paramStr.split(" ");
 				for (String param : params) {
 					if (param.endsWith(".mp4")) {
-						String filename = param.replace("%NAME%", depthName);
+						String filename = param.replace("%NAME%", colorName + "depthBuffer");
 						if (Files.exists(CaptureSession.singleton.getCaptureDir().resolve(filename))) {
 							outputs.clear();
 							throw new MinemaException(I18n.format("minema.error.file_exists", filename));

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/export/FrameExporter.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/export/FrameExporter.java
@@ -23,7 +23,6 @@ public abstract class FrameExporter {
 	protected String movieName;
 	protected int width;
 	protected int height;
-	protected int bitsPerChannel;
 	protected ExecutorService exportService;
 	protected Future<?> exportFuture;
 
@@ -31,11 +30,10 @@ public abstract class FrameExporter {
 		exportService = Executors.newSingleThreadExecutor();
 	}
 
-	public void enable(String movieName, int width, int height, int bitsPerChannel) throws Exception {
+	public void enable(String movieName, int width, int height) throws Exception {
 		this.movieName = movieName;
 		this.width = width;
 		this.height = height;
-		this.bitsPerChannel = bitsPerChannel;
 	}
 
 	public void destroy() throws Exception {

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/export/FrameExporter.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/export/FrameExporter.java
@@ -23,6 +23,7 @@ public abstract class FrameExporter {
 	protected String movieName;
 	protected int width;
 	protected int height;
+	protected int bitsPerChannel;
 	protected ExecutorService exportService;
 	protected Future<?> exportFuture;
 
@@ -30,10 +31,11 @@ public abstract class FrameExporter {
 		exportService = Executors.newSingleThreadExecutor();
 	}
 
-	public void enable(String movieName, int width, int height) throws Exception {
+	public void enable(String movieName, int width, int height, int bitsPerChannel) throws Exception {
 		this.movieName = movieName;
 		this.width = width;
 		this.height = height;
+		this.bitsPerChannel = bitsPerChannel;
 	}
 
 	public void destroy() throws Exception {

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/export/PipeFrameExporter.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/export/PipeFrameExporter.java
@@ -112,14 +112,17 @@ public class PipeFrameExporter extends FrameExporter {
 			}
 			else
 			{
-				if (this.isColor)
+				/* dont do linear mixing for 32 bit depth buffer - I could not make it work */
+				boolean linearMixingCondition = (cfg.depthBufferMotionBlur.get() || this.isColor) && !(!this.isColor && MinemaConfig.depthBufferBitDepth.get().getBytesPerChannel() == 4);
+
+				if (linearMixingCondition)
 				{
 					defvf += cfg.motionBlurLinearMixing.get() ? ",format=pix_fmts=rgba64le,lutrgb=r=gammaval(2.2):g=gammaval(2.2):b=gammaval(2.2)" : "";
 				}
 
 				for (int i = 0; i < cfg.motionBlurLevel.get().getExp(cfg.frameRate.get()); i++)
 				{
-					if (this.isColor)
+					if (cfg.depthBufferMotionBlur.get() || this.isColor)
 					{
 						defvf += ",tblend=all_mode=average,framestep=2";
 					}
@@ -129,7 +132,7 @@ public class PipeFrameExporter extends FrameExporter {
 					}
 				}
 
-				if (this.isColor)
+				if (linearMixingCondition)
 				{
 					defvf += cfg.motionBlurLinearMixing.get() ? ",lutrgb=r=gammaval(1/2.2):g=gammaval(1/2.2):b=gammaval(1/2.2)" : "";
 				}

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/export/PipeFrameExporter.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/export/PipeFrameExporter.java
@@ -102,15 +102,39 @@ public class PipeFrameExporter extends FrameExporter {
 		params = params.replace("%NAME%", movieName);
 
 		String defvf = "vflip";
+
 		if (cfg.motionBlurLevel.get() != MotionBlur.DISABLE)
+		{
 			if (!params.contains("%DEFVF%"))
+			{
 				throw new MinemaException(I18n.format("minema.error.require_defvf"));
-			else {
-				defvf += cfg.motionBlurLinearMixing.get() ? ",format=pix_fmts=rgba64le,lutrgb=r=gammaval(2.2):g=gammaval(2.2):b=gammaval(2.2)" : "";
-				for (int i = 0; i < cfg.motionBlurLevel.get().getExp(cfg.frameRate.get()); i++)
-					defvf += ",tblend=all_mode=average,framestep=2";
-				defvf += cfg.motionBlurLinearMixing.get() ? ",lutrgb=r=gammaval(1/2.2):g=gammaval(1/2.2):b=gammaval(1/2.2)" : "";
 			}
+			else
+			{
+				if (this.isColor)
+				{
+					defvf += cfg.motionBlurLinearMixing.get() ? ",format=pix_fmts=rgba64le,lutrgb=r=gammaval(2.2):g=gammaval(2.2):b=gammaval(2.2)" : "";
+				}
+
+				for (int i = 0; i < cfg.motionBlurLevel.get().getExp(cfg.frameRate.get()); i++)
+				{
+					if (this.isColor)
+					{
+						defvf += ",tblend=all_mode=average,framestep=2";
+					}
+					else
+					{
+						defvf += ",tblend=all_mode=normal,framestep=2";
+					}
+				}
+
+				if (this.isColor)
+				{
+					defvf += cfg.motionBlurLinearMixing.get() ? ",lutrgb=r=gammaval(1/2.2):g=gammaval(1/2.2):b=gammaval(1/2.2)" : "";
+				}
+			}
+		}
+
 		params = params.replace("%DEFVF%", defvf);
 
 		List<String> cmds = new ArrayList<>();

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/export/PipeFrameExporter.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/export/PipeFrameExporter.java
@@ -12,6 +12,7 @@ package info.ata4.minecraft.minema.client.modules.video.export;
 import info.ata4.minecraft.minema.CaptureSession;
 import info.ata4.minecraft.minema.Minema;
 import info.ata4.minecraft.minema.client.config.MinemaConfig;
+import info.ata4.minecraft.minema.client.config.enums.BitDepth;
 import info.ata4.minecraft.minema.client.config.enums.MotionBlur;
 import info.ata4.minecraft.minema.client.modules.modifiers.TimerModifier;
 import info.ata4.minecraft.minema.client.util.CaptureTime;
@@ -29,6 +30,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -77,8 +79,17 @@ public class PipeFrameExporter extends FrameExporter {
 		}
 		else if (!this.isColor)
 		{
-			//params = cfg.depthBufferBitDepth.get().getParams();
 			params = cfg.videoEncoderParamsDepth.get();
+
+			if (cfg.depthBufferBitDepth.get() != BitDepth.BIT8)
+			{
+				String depthSequencePath = path.toUri().toString().replace("file:///", "") + movieName + "_depth/";
+
+				if (new File(depthSequencePath).mkdirs())
+				{
+					path = Paths.get(depthSequencePath);
+				}
+			}
 		}
 		else
 		{

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/export/PipeFrameExporter.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/export/PipeFrameExporter.java
@@ -57,8 +57,8 @@ public class PipeFrameExporter extends FrameExporter {
 	}
 
 	@Override
-	public void enable(String movieName, int width, int height) throws Exception {
-		super.enable(movieName, width, height);
+	public void enable(String movieName, int width, int height, int bitsPerChannel) throws Exception {
+		super.enable(movieName, width, height, bitsPerChannel);
 
 		MinemaConfig cfg = Minema.instance.getConfig();
 		Path path = CaptureSession.singleton.getCaptureDir();
@@ -74,6 +74,12 @@ public class PipeFrameExporter extends FrameExporter {
 		params = params.replace("%HEIGHT%", String.valueOf(height));
 		params = params.replace("%FPS%", String.valueOf(cfg.getFrameRate()));
 		params = params.replace("%NAME%", movieName);
+
+		if (bitsPerChannel > 8)
+		{
+			params = params.replace("bgr24", "bgr48be");
+		}
+
 		String defvf = "vflip";
 		if (cfg.motionBlurLevel.get() != MotionBlur.DISABLE)
 			if (!params.contains("%DEFVF%"))

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/export/PipeFrameExporter.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/export/PipeFrameExporter.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -83,11 +84,11 @@ public class PipeFrameExporter extends FrameExporter {
 
 			if (cfg.depthBufferBitDepth.get() != BitDepth.BIT8)
 			{
-				String depthSequencePath = path.toUri().toString().replace("file:///", "") + movieName + "_depth/";
+				path = path.resolve(movieName + "_depth/");
 
-				if (new File(depthSequencePath).mkdirs())
+				if (!Files.exists(path))
 				{
-					path = Paths.get(depthSequencePath);
+					Files.createDirectory(path);
 				}
 			}
 		}

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/video/export/PipeFrameExporter.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/video/export/PipeFrameExporter.java
@@ -57,8 +57,8 @@ public class PipeFrameExporter extends FrameExporter {
 	}
 
 	@Override
-	public void enable(String movieName, int width, int height, int bitsPerChannel) throws Exception {
-		super.enable(movieName, width, height, bitsPerChannel);
+	public void enable(String movieName, int width, int height) throws Exception {
+		super.enable(movieName, width, height);
 
 		MinemaConfig cfg = Minema.instance.getConfig();
 		Path path = CaptureSession.singleton.getCaptureDir();
@@ -69,16 +69,26 @@ public class PipeFrameExporter extends FrameExporter {
 			throw new MinemaException(I18n.format("minema.error.ffmpeg_not_exists", ffmpeg));
 		}
 
-		String params = this.isColor && cfg.useAlpha.get() ? cfg.videoEncoderParamsAlpha.get() : cfg.videoEncoderParams.get();
+		String params;
+
+		if (this.isColor && cfg.useAlpha.get())
+		{
+			params = cfg.videoEncoderParamsAlpha.get();
+		}
+		else if (!this.isColor)
+		{
+			//params = cfg.depthBufferBitDepth.get().getParams();
+			params = cfg.videoEncoderParamsDepth.get();
+		}
+		else
+		{
+			params = cfg.videoEncoderParams.get();
+		}
+
 		params = params.replace("%WIDTH%", String.valueOf(width));
 		params = params.replace("%HEIGHT%", String.valueOf(height));
 		params = params.replace("%FPS%", String.valueOf(cfg.getFrameRate()));
 		params = params.replace("%NAME%", movieName);
-
-		if (bitsPerChannel > 8)
-		{
-			params = params.replace("bgr24", "bgr48be");
-		}
 
 		String defvf = "vflip";
 		if (cfg.motionBlurLevel.get() != MotionBlur.DISABLE)

--- a/src/main/java/info/ata4/minecraft/minema/util/config/ConfigEnum.java
+++ b/src/main/java/info/ata4/minecraft/minema/util/config/ConfigEnum.java
@@ -47,7 +47,7 @@ public class ConfigEnum<T extends Enum<T>> extends ConfigValue<T> {
 	}
 
 	@Override
-	protected Property getProp() {
+	public Property getProp() {
 		Property prop = super.getProp();
 		prop.setValidValues(validValues);
 		return prop;

--- a/src/main/java/info/ata4/minecraft/minema/util/config/ConfigString.java
+++ b/src/main/java/info/ata4/minecraft/minema/util/config/ConfigString.java
@@ -32,6 +32,13 @@ public class ConfigString extends ConfigValue<String> {
     }
 
     @Override
+    public Property getProp() {
+        Property prop = super.getProp();
+
+        return prop;
+    }
+
+    @Override
     public void set(String value) {
         getProp().set(value);
     }

--- a/src/main/resources/assets/minema/lang/en_US.lang
+++ b/src/main/resources/assets/minema/lang/en_US.lang
@@ -78,6 +78,15 @@ minema.config.videoEncoderParams.tooltip=Arguments for the video encoding progra
 minema.config.videoEncoderParamsAlpha=Encoder Arguments (alpha)
 minema.config.videoEncoderParamsAlpha.tooltip=Arguments for the video encoding program when 'Use alpha' option is enabled. Placeholders are the same. For PNG sequences, you could use "-f rawvideo -pix_fmt rgb32 -s %%WIDTH%%x%%HEIGHT%% -r %%FPS%% -i - -vf vflip %%NAME%%_%%d.png".
 
+minema.config.videoEncoderParamsDepth=Encoder Arguments (depth buffer)
+minema.config.videoEncoderParamsDepth.tooltip=Arguments for exporting the depth buffer when 'Use depth' option is enabled. Placeholders are the same.
+
+minema.config.depthBufferBitDepth=Bit Depth for depth buffer
+minema.config.depthBufferBitDepth.tooltip=The bit depth that should be used internally for the depth buffer.
+
+minema.config.depthBufferLinearize=Linearize depth buffer
+minema.config.depthBufferBitDepth.tooltip=TO DO.
+
 minema.config.snapResolution=Snap Resolution
 minema.config.snapResolution.tooltip=If necessary, snaps the recording resolution to the next lower resolution so that width and height is divisible by this modulus. FFMpeg only needs mod2, some other encoders might need more.
 

--- a/src/main/resources/assets/minema/lang/en_US.lang
+++ b/src/main/resources/assets/minema/lang/en_US.lang
@@ -81,8 +81,11 @@ minema.config.videoEncoderParamsAlpha.tooltip=Arguments for the video encoding p
 minema.config.videoEncoderParamsDepth=Encoder Arguments (depth buffer)
 minema.config.videoEncoderParamsDepth.tooltip=Arguments for exporting the depth buffer when 'Use depth' option is enabled. Placeholders are the same. Example arguments: 8 bits "-f rawvideo -pix_fmt bgr24 -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -c:v libx264 -preset ultrafast -tune zerolatency -qp 6 -pix_fmt yuv420p %NAME%_depth.mp4",\n16 bits 4 channels "-f rawvideo -pix_fmt bgra64be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -pix_fmt bgra64be %NAME%_depth_%d.png",\n32 bits float "-f rawvideo -pix_fmt gbrpf32be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -compression zip1 -pix_fmt gbrpf32le %NAME%_depth_%d.exr"
 
+minema.config.depthBufferMotionBlur=Depth buffer motion blur
+minema.config.depthBufferMotionBlur.tooltip=Use motion blur in the depth buffer when motion blur is activated in the capturing settings. Motion blur in the depth buffer is not very useful for masking, but useful for post process DOF.
+
 minema.config.depthBufferBitDepth=Bit depth for depth buffer
-minema.config.depthBufferBitDepth.tooltip=The bit depth that should be used internally for the depth buffer. 16 bits with 4 channels saves the render distance or the manually defined distance in the alpha channel. 32 bits saves the depth values multiplied with the render distance in the green channel.
+minema.config.depthBufferBitDepth.tooltip=The bit depth that should be used internally for the depth buffer. 16 bits with 4 channels saves the render distance or the manually defined distance in the alpha channel. 32 bits saves the depth values multiplied with the render distance.
 
 minema.config.snapResolution=Snap Resolution
 minema.config.snapResolution.tooltip=If necessary, snaps the recording resolution to the next lower resolution so that width and height is divisible by this modulus. FFMpeg only needs mod2, some other encoders might need more.

--- a/src/main/resources/assets/minema/lang/en_US.lang
+++ b/src/main/resources/assets/minema/lang/en_US.lang
@@ -79,13 +79,10 @@ minema.config.videoEncoderParamsAlpha=Encoder Arguments (alpha)
 minema.config.videoEncoderParamsAlpha.tooltip=Arguments for the video encoding program when 'Use alpha' option is enabled. Placeholders are the same. For PNG sequences, you could use "-f rawvideo -pix_fmt rgb32 -s %%WIDTH%%x%%HEIGHT%% -r %%FPS%% -i - -vf vflip %%NAME%%_%%d.png".
 
 minema.config.videoEncoderParamsDepth=Encoder Arguments (depth buffer)
-minema.config.videoEncoderParamsDepth.tooltip=Arguments for exporting the depth buffer when 'Use depth' option is enabled. Placeholders are the same.
+minema.config.videoEncoderParamsDepth.tooltip=Arguments for exporting the depth buffer when 'Use depth' option is enabled. Placeholders are the same. Example arguments: 8 bits "-f rawvideo -pix_fmt bgr24 -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -c:v libx264 -preset ultrafast -tune zerolatency -qp 6 -pix_fmt yuv420p %NAME%_depth.mp4",\n16 bits 4 channels "-f rawvideo -pix_fmt bgra64be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -pix_fmt bgra64be %NAME%_depth_%d.png",\n32 bits float "-f rawvideo -pix_fmt gbrpf32be -s %WIDTH%x%HEIGHT% -r %FPS% -i - -vf %DEFVF% -preset ultrafast -tune zerolatency -qp 6 -compression zip1 -pix_fmt gbrpf32le %NAME%_depth_%d.exr"
 
-minema.config.depthBufferBitDepth=Bit Depth for depth buffer
-minema.config.depthBufferBitDepth.tooltip=The bit depth that should be used internally for the depth buffer.
-
-minema.config.depthBufferLinearize=Linearize depth buffer
-minema.config.depthBufferBitDepth.tooltip=TO DO.
+minema.config.depthBufferBitDepth=Bit depth for depth buffer
+minema.config.depthBufferBitDepth.tooltip=The bit depth that should be used internally for the depth buffer. 16 bits with 4 channels saves the render distance or the manually defined distance in the alpha channel. 32 bits saves the depth values multiplied with the render distance in the green channel.
 
 minema.config.snapResolution=Snap Resolution
 minema.config.snapResolution.tooltip=If necessary, snaps the recording resolution to the next lower resolution so that width and height is divisible by this modulus. FFMpeg only needs mod2, some other encoders might need more.


### PR DESCRIPTION
Unfortunately, I can not make GPU acceleration work for this, so people have to take in the cost of heavier performance.

- Added 16 and 32 bit depth buffer option
    - 16 bit has 3 channels and 4 channels option. The 4 channel option will save the render distance or the custom depth buffer limit in the alpha channel so it can later be extracted and multiplied again to produce an accurate depth pass.
    - 32 bit saves the depth buffer (already multiplied with render distance or custom limit) using planar format - the rgb channels are separate byte buffers instead of rgb per pixel as this is what most 32 bit capable image formats (like openEXR) use
- Added button to decide whether depth buffer should experience motion blur
- Added bit depth encoding parameters for further customisation - if you change the bit depth you have to reset the parameters to default or change them manually to adapt to the bit depth
- Added injection after CyclicEntry updates the text - change the default value of the depth buffer encoding parameters based on the bit depth chosen